### PR TITLE
Convert the API to types and extension traits.

### DIFF
--- a/iomux/src/main.rs
+++ b/iomux/src/main.rs
@@ -2,7 +2,7 @@ mod options;
 
 use self::options::Options;
 use futures::StreamExt;
-use tokio_childstream::{spawn_stream, ChildItem::*};
+use tokio_childstream::{ChildItem::*, CommandExt};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
@@ -11,7 +11,7 @@ async fn main() -> anyhow::Result<()> {
     let mut streams = vec![];
     for (i, mut cmd) in opts.subcommands.into_iter().enumerate() {
         println!("{}I: Spawning {:?}", i, cmd.as_std());
-        let stream = spawn_stream(&mut cmd)?;
+        let stream = cmd.spawn_stream()?;
         streams.push(stream.map(move |event| (i, event)));
     }
 

--- a/tokio-childstream/src/commandext.rs
+++ b/tokio-childstream/src/commandext.rs
@@ -1,0 +1,19 @@
+use crate::ChildStream;
+use tokio::process::Command;
+
+/// Extend [tokio::process::Command] to enable spawning a child directly into a [ChildStream]
+pub trait CommandExt {
+    /// Spawn a child process and convert it into a [ChildStream]
+    fn spawn_stream(&mut self) -> std::io::Result<ChildStream>;
+}
+
+impl CommandExt for Command {
+    fn spawn_stream(&mut self) -> std::io::Result<ChildStream> {
+        use std::process::Stdio;
+
+        self.stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map(ChildStream::from)
+    }
+}

--- a/tokio-childstream/src/item.rs
+++ b/tokio-childstream/src/item.rs
@@ -1,0 +1,15 @@
+use bytes::Bytes;
+use std::process::ExitStatus;
+
+/// Represents events from a [ChildStream](crate::ChildStream)
+#[derive(Debug)]
+pub enum ChildItem {
+    /// Bytes read from the child's stdout
+    Stdout(Bytes),
+
+    /// Bytes read from the child's stderr
+    Stderr(Bytes),
+
+    /// The [ExitStatus] of the child
+    Exit(ExitStatus),
+}

--- a/tokio-childstream/src/lib.rs
+++ b/tokio-childstream/src/lib.rs
@@ -1,8 +1,12 @@
 #![doc = include_str!("../README.md")]
 
+mod commandext;
+mod item;
 mod stream;
 
-pub use self::stream::{child_stream, spawn_stream, ChildItem};
+pub use self::commandext::CommandExt;
+pub use self::item::ChildItem;
+pub use self::stream::ChildStream;
 
 #[cfg(test)]
 mod tests;

--- a/tokio-childstream/src/stream.rs
+++ b/tokio-childstream/src/stream.rs
@@ -1,69 +1,14 @@
-use bytes::Bytes;
-use futures::{Stream, StreamExt};
-use std::process::ExitStatus;
-use tokio::process::Child;
-use tokio::process::Command;
-use tokio_util::io::ReaderStream;
+mod fromchild;
+mod streamimpl;
 
-/// Spawn `command` and conver the child into a stream of [ChildItem]
-pub fn spawn_stream(
-    command: &mut Command,
-) -> std::io::Result<impl Stream<Item = std::io::Result<ChildItem>>> {
-    use std::process::Stdio;
+use crate::ChildItem;
+use futures::channel::mpsc;
 
-    command
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map(child_stream)
-}
-
-/// Convert a [Child] into a stream over [ChildItem] events
-pub fn child_stream(mut child: Child) -> impl Stream<Item = std::io::Result<ChildItem>> {
-    use futures::channel::mpsc;
-    use ChildItem::*;
-
-    let optout = child.stdout.take();
-    let opterr = child.stderr.take();
-
-    let (sender, receiver) = mpsc::unbounded();
-
-    if let Some(stdout) = optout {
-        let outsender = sender.clone();
-        tokio::task::spawn(async move {
-            let mut stream = ReaderStream::new(stdout);
-            while let Some(bytesres) = stream.next().await {
-                outsender.unbounded_send(bytesres.map(Stdout)).unwrap();
-            }
-        });
-    }
-
-    if let Some(stderr) = opterr {
-        let errsender = sender.clone();
-        tokio::task::spawn(async move {
-            let mut stream = ReaderStream::new(stderr);
-            while let Some(bytesres) = stream.next().await {
-                errsender.unbounded_send(bytesres.map(Stderr)).unwrap();
-            }
-        });
-    }
-
-    tokio::task::spawn(async move {
-        sender.unbounded_send(child.wait().await.map(Exit)).unwrap();
-    });
-
-    receiver
-}
-
-/// Represents events from a [Child]
+/// Provide a [Stream](futures::Stream) over [std::io::Result]s of [ChildItem]s
+///
+/// Convert a [tokio::process::Child] with [ChildStream::from].
+///
+/// To spawn a [ChildStream] directly from [tokio::process::Command] see
+/// [CommandExt::spawn_stream](crate::CommandExt::spawn_stream).
 #[derive(Debug)]
-pub enum ChildItem {
-    /// Bytes read from the child's stdout
-    Stdout(Bytes),
-
-    /// Bytes read from the child's stderr
-    Stderr(Bytes),
-
-    /// The [ExitStatus] of the child
-    Exit(ExitStatus),
-}
+pub struct ChildStream(mpsc::UnboundedReceiver<std::io::Result<ChildItem>>);

--- a/tokio-childstream/src/stream/streamimpl.rs
+++ b/tokio-childstream/src/stream/streamimpl.rs
@@ -1,0 +1,18 @@
+use super::ChildStream;
+use crate::ChildItem;
+use futures::task::{Context, Poll};
+use futures::Stream;
+use std::pin::Pin;
+
+impl Stream for ChildStream {
+    type Item = std::io::Result<ChildItem>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mutself = Pin::into_inner(self);
+        Stream::poll_next(Pin::new(&mut mutself.0), cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}

--- a/tokio-childstream/src/tests.rs
+++ b/tokio-childstream/src/tests.rs
@@ -1,12 +1,12 @@
 // TODO: These tests are platform-specific, assuming unixy utilities are present.
 
-use crate::{spawn_stream, ChildItem::*};
+use crate::{ChildItem::*, CommandExt};
 use futures::StreamExt;
 use tokio::process::Command;
 
 #[tokio::test]
 async fn exit_0() {
-    let mut stream = spawn_stream(&mut Command::new("true")).unwrap();
+    let mut stream = Command::new("true").spawn_stream().unwrap();
     let event = stream.next().await.unwrap();
     assert!(stream.next().await.is_none());
     match event {
@@ -19,7 +19,11 @@ async fn exit_0() {
 
 #[tokio::test]
 async fn hello_world() {
-    let mut stream = spawn_stream(&mut Command::new("echo").arg("hello").arg("world")).unwrap();
+    let mut stream = Command::new("echo")
+        .arg("hello")
+        .arg("world")
+        .spawn_stream()
+        .unwrap();
     let mut found_hw = false;
     let mut found_exit = false;
     while let Some(event) = stream.next().await {
@@ -40,8 +44,11 @@ async fn hello_world() {
 
 #[tokio::test]
 async fn stderr_hello_world() {
-    let mut stream =
-        spawn_stream(&mut Command::new("bash").arg("-c").arg("echo 'hello world' >&2")).unwrap();
+    let mut stream = Command::new("bash")
+        .arg("-c")
+        .arg("echo 'hello world' >&2")
+        .spawn_stream()
+        .unwrap();
     let mut found_hw = false;
     let mut found_exit = false;
     while let Some(event) = stream.next().await {


### PR DESCRIPTION
This is a much cleaner API for consumers.